### PR TITLE
https://issues.jenkins-ci.org/browse/JENKINS-10769

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ work
 *.iml
 *.ipr
 *.iws
+.classpath
+.project

--- a/src/main/java/com/thalesgroup/hudson/plugins/cccc/CcccChartBuilder.java
+++ b/src/main/java/com/thalesgroup/hudson/plugins/cccc/CcccChartBuilder.java
@@ -135,17 +135,17 @@ public class CcccChartBuilder extends Graph {
                 CcccReport report = result.getReport();
                 NumberOnlyBuildLabel buildLabel = new NumberOnlyBuildLabel(action.getBuild());
 
-                try {
-                    Class projectSummaryClass = ProjectSummary.class;
-                    Method method = projectSummaryClass.getMethod("nbNodules");
-                    Number n = (Number) method.invoke(report.getStructuralSummaryModuleList());
-                } catch (NoSuchMethodException nse) {
-                    throw new CCCCException(nse);
-                } catch (IllegalAccessException iae) {
-                    throw new CCCCException(iae);
-                } catch (InvocationTargetException ite) {
-                    throw new CCCCException(ite);
-                }
+//                try {
+//                    Class projectSummaryClass = ProjectSummary.class;
+//                    Method method = projectSummaryClass.getMethod("nbNodules");
+//                    Number n = (Number) method.invoke(report.getStructuralSummaryModuleList());
+//                } catch (NoSuchMethodException nse) {
+//                    throw new CCCCException(nse);
+//                } catch (IllegalAccessException iae) {
+//                    throw new CCCCException(iae);
+//                } catch (InvocationTargetException ite) {
+//                    throw new CCCCException(ite);
+//                }
                 if (report.getProjectSummary() == null)
                     builder.add(0, "Number of module", buildLabel);
                 else


### PR DESCRIPTION
This commit "fixes" the issue mentioned in the topic. The code commented out in the commit seems to have no effect, since it's all inside the try-catch clause, unless it has side effects. I would have fixed the code propperly but couldn't guess what method actually should be reflected and what object should be used in the invoce call.

The actual cause is the typo in the reflection method name and causes the following stack trace in Jenkins:

com.thalesgroup.hudson.plugins.cccc.CCCCException: java.lang.NoSuchMethodException: com.thalesgroup.hudson.plugins.cccc.model.ProjectSummary.nbNodules()
    at com.thalesgroup.hudson.plugins.cccc.CcccChartBuilder.buildDataset(CcccChartBuilder.java:143)
    at com.thalesgroup.hudson.plugins.cccc.CcccChartBuilder.createGraph(CcccChartBuilder.java:63)
    at hudson.util.Graph.render(Graph.java:87)
    at hudson.util.Graph.doPng(Graph.java:98)
    at com.thalesgroup.hudson.plugins.cccc.CcccProjectAction.doGraph(CcccProjectAction.java:123)
...
